### PR TITLE
Fix install command documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or
 In Shell
 
 ```sh
-composer require -dev ccinn/composer-husky-plugin ccinn/husky-php
+composer require --dev ccinn/composer-husky-plugin ccinn/husky-php
 ```
 
 ## Usage


### PR DESCRIPTION
Just fix the composer require command on documentation so people can easily copy and paste the command on their terminals.